### PR TITLE
Don't retry if RESOURCE_EXHAUSTED or CANCELLED error received

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,16 @@ Read more about the Spice.ai Async HTTP API at [docs.spice.ai](https://docs.spic
 
 ### Configuring retry policy
 
-Starting from [version 1.0.1](https://github.com/spiceai/spice.js/releases/tag/v1.0.1) the `SpiceClient` implements connection retrying mechanism (3 attemps by default).
-This could be configured or disabled using `setMaxRetries`:
+From [version 1.0.1](https://github.com/spiceai/spice.js/releases/tag/v1.0.1) the `SpiceClient` implements connection retry mechanism (3 attemps by default).
+The number of attempts can be configured via `setMaxRetries`:
 
 ```
 const spiceClient = new SpiceClient('API_KEY');
 spiceClient.setMaxRetries(5); // Setting to 0 will disable retries
 ```
 
-Note: Retries are automatically performed for connection and system internal errors. However, it is the responsibility of
-the SDK user to properly handle errors such as RESOURCE_EXHAUSTED or similar. This error indicates that the user's quota has
-been reached, and it may be necessary to decide whether to retry the request later or to add a throttling mechanism.
+Retries are performed for connection and system internal errors. It is the SDK user's responsibility to properly
+handle other errors, for example RESOURCE_EXHAUSTED (HTTP 429).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Read more about the Spice.ai Async HTTP API at [docs.spice.ai](https://docs.spic
 
 ### Connection retry
 
-From [version 1.0.1](https://github.com/spiceai/spice.js/releases/tag/v1.0.1) the `SpiceClient` implements connection retry mechanism (3 attemps by default).
+From [version 1.0.1](https://github.com/spiceai/spice.js/releases/tag/v1.0.1) the `SpiceClient` implements connection retry mechanism (3 attempts by default).
 The number of attempts can be configured via `setMaxRetries`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -66,11 +66,17 @@ Read more about the Spice.ai Async HTTP API at [docs.spice.ai](https://docs.spic
 
 ### Configuring retry policy
 
-SDK performs 3 retry attempts when using Apache Arrow Flight API. This could be configured as 
+Starting from [version 1.0.1](https://github.com/spiceai/spice.js/releases/tag/v1.0.1) the `SpiceClient` implements connection retrying mechanism (3 attemps by default).
+This could be configured or disabled using `setMaxRetries`:
+
 ```
 const spiceClient = new SpiceClient('API_KEY');
 spiceClient.setMaxRetries(5); // Setting to 0 will disable retries
 ```
+
+Note: Retries are automatically performed for connection and system internal errors. However, it is the responsibility of
+the SDK user to properly handle errors such as RESOURCE_EXHAUSTED or similar. This error indicates that the user's quota has
+been reached, and it may be necessary to decide whether to retry the request immediately or to add throttling mechanism.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ spiceClient.setMaxRetries(5); // Setting to 0 will disable retries
 
 Note: Retries are automatically performed for connection and system internal errors. However, it is the responsibility of
 the SDK user to properly handle errors such as RESOURCE_EXHAUSTED or similar. This error indicates that the user's quota has
-been reached, and it may be necessary to decide whether to retry the request immediately or to add throttling mechanism.
+been reached, and it may be necessary to decide whether to retry the request later or to add a throttling mechanism.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ main();
 
 Read more about the Spice.ai Async HTTP API at [docs.spice.ai](https://docs.spice.ai/api/sql-query-api/http-api-1).
 
-### Configuring retry policy
+### Connection retry
 
 From [version 1.0.1](https://github.com/spiceai/spice.js/releases/tag/v1.0.1) the `SpiceClient` implements connection retry mechanism (3 attemps by default).
 The number of attempts can be configured via `setMaxRetries`:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spiceai/spice",
   "description": "JS + TS SDK for spice.ai",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -22,10 +22,8 @@ function shouldRetryOperationForError(err: any): boolean {
   }
 
   return [
-    grpc.status.CANCELLED,
     grpc.status.UNAVAILABLE,
     grpc.status.DEADLINE_EXCEEDED,
-    grpc.status.RESOURCE_EXHAUSTED,
     grpc.status.ABORTED,
     grpc.status.INTERNAL,
   ].includes(code);

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -26,6 +26,7 @@ function shouldRetryOperationForError(err: any): boolean {
     grpc.status.DEADLINE_EXCEEDED,
     grpc.status.ABORTED,
     grpc.status.INTERNAL,
+    grpc.status.UNKNOWN,
   ].includes(code);
 }
 


### PR DESCRIPTION
Note: I've enabled retry additionally for UNKNOWN error as part of this change:

https://chromium.googlesource.com/external/github.com/grpc/grpc/+/refs/tags/v1.21.4-pre1/doc/statuscodes.md


Unknown error. For example, this error may be returned when a Status value received from another address space belongs to an error space that is not known in this address space. Also errors raised by APIs that do not return enough error information may be converted to this error.