### PR TITLE
Fix missing default params

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -50,7 +50,7 @@ class SpiceClient {
   private _flight_tls_enabled: boolean = true;
   private _maxRetries: number = retry.FLIGHT_QUERY_MAX_RETRIES;
 
-  public constructor(params: string | SpiceClientConfig) {
+  public constructor(params: string | SpiceClientConfig = {}) {
     // support legacy constructor with api_key as first agument
     if (typeof params === 'string') {
       this._apiKey = params;

--- a/test/local-runtime.test.ts
+++ b/test/local-runtime.test.ts
@@ -1,7 +1,7 @@
 import { SpiceClient } from '../';
 
 describe('local', () => {
-  const client = new SpiceClient({});
+  const client = new SpiceClient();
 
   it('connection and query to local spice runtime works', async () => {
     const tableResult = await client.query(


### PR DESCRIPTION
Fixed the error when client created with empty params `const client = new SpiceClient();