### PR TITLE
Fix tests in npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - run: yarn install
       - run: yarn build
       - run: |
-          yarn test
+          yarn test -t 'cloud'
         env:
           API_KEY: ${{ secrets.API_KEY }}
           RELAY_KEY: ${{ secrets.RELAY_KEY }}


### PR DESCRIPTION
Run only cloud tests before publishing to npm. Local runtime tested on each push.