### PR TITLE
fix: Call spiced directly to avoid CLI re-downloading Runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
           SPICE_SECRET_POSTGRES_PASSWORD: postgres
         working-directory: test/scripts
         run: |
-          spice run &> spice.log &
+          spiced &> spice.log &
           # time to initialize added dataset
           sleep 10
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
-          spice upgrade
+          $HOME/.spice/bin/spice upgrade
       
       - name: Install Spice (https://install.spiceai.org) (MacOS)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
           createdb testdb
 
       - name: Wait for PostgreSQL to start
-        run: sleep 10
+        run: sleep 5
 
       - name: Check PostgreSQL
         env:
@@ -101,6 +101,7 @@ jobs:
         run: |
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
+          spice upgrade
       
       - name: Install Spice (https://install.spiceai.org) (MacOS)
         if: matrix.os == 'macos-latest'
@@ -118,7 +119,7 @@ jobs:
         run: |
           spiced &> spice.log &
           # time to initialize added dataset
-          sleep 10
+          sleep 2
 
       - name: Running tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
-          $HOME/.spice/bin/spice upgrade
+          $HOME/.spice/bin/spice install
       
       - name: Install Spice (https://install.spiceai.org) (MacOS)
         if: matrix.os == 'macos-latest'


### PR DESCRIPTION
## 🗣 Description

* Call `spiced` directly in integration tests to avoid CLI re-downloading the runtime