### PR TITLE
Fix spice installation in macos tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,22 +15,24 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.version.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version: [
-          { os: 'ubuntu-latest', nodever: 22 },
-          { os: 'macos-latest', nodever: 22 },
-        ]
-    name: Test with spice runtime on ${{ matrix.version.os }} Node.JS ${{ matrix.version.nodever }}
+        os:
+          - ubuntu-latest
+          - macos-latest
+        node:
+          - 22
+          # - 24 - Node.JS 24 will be released in Apr 2025
+    name: Test with spice runtime on ${{ matrix.os }} Node.JS ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.version.nodever }}
+          node-version: ${{ matrix.node }}
 
       - name: Install requirements
         run: |
@@ -38,7 +40,7 @@ jobs:
           yarn build
 
       - name: Install PostgreSQL (Linux)
-        if: matrix.version.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt-get install -y postgresql
@@ -49,7 +51,7 @@ jobs:
           sudo -u postgres createdb testdb
 
       - name: Install PostgreSQL (MacOS)
-        if: matrix.version.os == 'macos-latest'
+        if: matrix.os == 'macos-latest'
         run: |
           brew install postgresql
           brew services start postgresql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version.nodever }}
-      
+
       - name: Install requirements
         run: |
           yarn install
@@ -81,9 +81,11 @@ jobs:
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
           $HOME/.spice/bin/spice install
-      
+
       - name: Install Spice (https://install.spiceai.org) (MacOS)
         if: matrix.version.os == 'macos-latest'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           brew install spiceai/spiceai/spice
           brew install spiceai/spiceai/spiced

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,21 +74,12 @@ jobs:
           psql -h localhost -U postgres -d testdb -c 'SELECT * FROM test_postgresql_table;'
 
       - name: Install Spice (https://install.spiceai.org) (Linux)
-        if: matrix.version.os == 'ubuntu-latest'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> $GITHUB_PATH
           $HOME/.spice/bin/spice install
-
-      - name: Install Spice (https://install.spiceai.org) (MacOS)
-        if: matrix.version.os == 'macos-latest'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          brew install spiceai/spiceai/spice
-          brew install spiceai/spiceai/spiced
 
       - name: Check spice version
         run: spice version


### PR DESCRIPTION
MacOS tests are failing due to GitHub rate limiting when spice checks for latest release https://github.com/spiceai/spice.js/actions/runs/13760032493/job/40115637680?pr=232

Updated test workflow to enable Node.js 24 once it is available in GitHub CI