### PR TITLE
Fix npm

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -52,9 +52,9 @@ jobs:
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
-      - run: yarn install
+      - run: npm install
       - run: node scripts/update-version.js # ensure the version in version.ts is updated
-      - run: yarn build
-      - run: yarn publish --access public
+      - run: npm run build
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the npm publish workflow to use npm instead of yarn for installing dependencies, building, and publishing the package. This helps standardize the workflow and may reduce issues related to using multiple package managers.

**Workflow changes:**

* Replaced `yarn install` with `npm install` to install dependencies in the `.github/workflows/npm-publish.yml` workflow.
* Updated build and publish steps to use `npm run build` and `npm publish` instead of their yarn equivalents.