### PR TITLE
Fix double z in timestamp conversion

### DIFF
--- a/src/__tests__/timezone-conversions.test.ts
+++ b/src/__tests__/timezone-conversions.test.ts
@@ -30,7 +30,7 @@ describe('Timezone Conversions', () => {
         httpUrl: 'http://localhost:8090',
       },
       mockPlatform,
-      mockRetry,
+      mockRetry
     );
   });
 

--- a/src/__tests__/timezone-conversions.test.ts
+++ b/src/__tests__/timezone-conversions.test.ts
@@ -277,4 +277,142 @@ describe('Timezone Conversions', () => {
       expect(result.data[0].ts_no_tz).not.toMatch(/Z$/);
     });
   });
+
+  describe('Double Z bug prevention', () => {
+    it('should not add double Z suffix for timestamps with non-.000 milliseconds', async () => {
+      const mockResponse = {
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            schema: {
+              fields: [
+                {
+                  name: 'created_at',
+                  data_type: 'Timestamp(Nanosecond, Some("UTC"))',
+                  nullable: true,
+                  dict_id: 0,
+                  dict_is_ordered: false,
+                  metadata: {},
+                },
+              ],
+            },
+            data: [
+              { created_at: '2025-10-03T18:56:10.790Z' },
+              { created_at: '2025-10-03T18:56:10.000Z' },
+              { created_at: '2025-10-03T18:56:10Z' },
+            ],
+          }),
+      };
+
+      (mockPlatform.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await client.sql('SELECT created_at FROM test');
+      const rows = result.toArray();
+
+      // Should not have double Z
+      expect(rows[0].created_at).toBe('2025-10-03T18:56:10.790Z');
+      expect(rows[0].created_at).not.toContain('ZZ');
+
+      expect(rows[1].created_at).toBe('2025-10-03T18:56:10Z');
+      expect(rows[1].created_at).not.toContain('ZZ');
+
+      expect(rows[2].created_at).toBe('2025-10-03T18:56:10Z');
+      expect(rows[2].created_at).not.toContain('ZZ');
+    });
+
+    it('should handle timestamps in nested structures without double Z', async () => {
+      const mockResponse = {
+        ok: true,
+        text: async () =>
+          JSON.stringify({
+            schema: {
+              fields: [
+                {
+                  name: 'events',
+                  data_type: 'List',
+                  nullable: true,
+                  dict_id: 0,
+                  dict_is_ordered: false,
+                  metadata: {},
+                  children: [
+                    {
+                      name: 'item',
+                      data_type: 'Struct',
+                      nullable: true,
+                      dict_id: 0,
+                      dict_is_ordered: false,
+                      metadata: {},
+                      children: [
+                        {
+                          name: 'timestamp',
+                          data_type: 'Timestamp(Nanosecond, Some("UTC"))',
+                          nullable: true,
+                          dict_id: 0,
+                          dict_is_ordered: false,
+                          metadata: {},
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            data: [
+              {
+                events: [
+                  { timestamp: '2025-10-03T18:56:10.790Z' },
+                  { timestamp: '2025-10-03T18:56:11.123Z' },
+                ],
+              },
+            ],
+          }),
+      };
+
+      (mockPlatform.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await client.sql('SELECT events FROM test');
+      const rows = result.toArray();
+
+      const events = JSON.parse(rows[0].events);
+      expect(events[0].timestamp).toBe('2025-10-03T18:56:10.790Z');
+      expect(events[0].timestamp).not.toContain('ZZ');
+      expect(events[1].timestamp).toBe('2025-10-03T18:56:11.123Z');
+      expect(events[1].timestamp).not.toContain('ZZ');
+    });
+
+    it('should not add double Z in sqlJson responses', async () => {
+      const mockResponse = {
+        ok: true,
+        json: async () => ({
+          schema: {
+            fields: [
+              {
+                name: 'created_at',
+                data_type: 'Timestamp(Nanosecond, Some("UTC"))',
+                nullable: true,
+              },
+            ],
+          },
+          data: [
+            { created_at: '2025-10-03T18:56:10.790Z' },
+            { created_at: '2025-10-03T18:56:10.000Z' },
+            { created_at: '2025-10-03T18:56:10Z' },
+          ],
+        }),
+      };
+
+      (mockPlatform.fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await client.sqlJson('SELECT created_at FROM test');
+
+      expect(result.data[0].created_at).toBe('2025-10-03T18:56:10.790Z');
+      expect(result.data[0].created_at).not.toContain('ZZ');
+
+      expect(result.data[1].created_at).toBe('2025-10-03T18:56:10Z');
+      expect(result.data[1].created_at).not.toContain('ZZ');
+
+      expect(result.data[2].created_at).toBe('2025-10-03T18:56:10Z');
+      expect(result.data[2].created_at).not.toContain('ZZ');
+    });
+  });
 });

--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -323,8 +323,8 @@ function wrapTableForDecimalConversion(table: Table): Table {
             let isoString = value.toISOString();
             // Remove milliseconds if .000
             isoString = isoString.replace(/\.000Z$/, '');
-            // Add Z back if has timezone, otherwise leave without Z
-            if (hasTimezone) {
+            // Add Z back if has timezone and doesn't already have it
+            if (hasTimezone && !isoString.endsWith('Z')) {
               isoString += 'Z';
             }
             convertedRow[field.name] = isoString;
@@ -335,8 +335,8 @@ function wrapTableForDecimalConversion(table: Table): Table {
             let isoString = date.toISOString();
             // Remove milliseconds if .000
             isoString = isoString.replace(/\.000Z$/, '');
-            // Add Z back if has timezone, otherwise leave without Z
-            if (hasTimezone) {
+            // Add Z back if has timezone and doesn't already have it
+            if (hasTimezone && !isoString.endsWith('Z')) {
               isoString += 'Z';
             }
             convertedRow[field.name] = isoString;
@@ -843,8 +843,8 @@ export class SpiceClient {
             let isoString = value.toISOString();
             // Remove milliseconds if .000
             isoString = isoString.replace(/\.000Z$/, '');
-            // Add Z back if has timezone, otherwise leave without Z
-            if (hasTimezone) {
+            // Add Z back if has timezone and doesn't already have it
+            if (hasTimezone && !isoString.endsWith('Z')) {
               isoString += 'Z';
             }
             return isoString;
@@ -861,8 +861,8 @@ export class SpiceClient {
               let isoString = date.toISOString();
               // Remove milliseconds if .000
               isoString = isoString.replace(/\.000Z$/, '');
-              // Add Z back if has timezone, otherwise leave without Z
-              if (hasTimezone) {
+              // Add Z back if has timezone and doesn't already have it
+              if (hasTimezone && !isoString.endsWith('Z')) {
                 isoString += 'Z';
               }
               return isoString;

--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -27,7 +27,7 @@ export interface RetryModule {
   dontRetry(err: any): void;
   retryWithExponentialBackoff<T>(
     operation: any,
-    maxRetries: number,
+    maxRetries: number
   ): Promise<T>;
 }
 
@@ -204,7 +204,7 @@ function wrapTableForDecimalConversion(table: Table): Table {
 
     // Check which fields need conversion
     const decimalFields = table.schema.fields.filter((f) =>
-      f.type.toString().startsWith('Decimal'),
+      f.type.toString().startsWith('Decimal')
     );
 
     // For timestamp fields, use original schema metadata if available
@@ -239,7 +239,7 @@ function wrapTableForDecimalConversion(table: Table): Table {
       timestampFields = table.schema.fields.filter(
         (f) =>
           f.type.toString().startsWith('Timestamp') ||
-          f.type.toString().startsWith('Date'),
+          f.type.toString().startsWith('Date')
       );
     }
 
@@ -259,12 +259,12 @@ function wrapTableForDecimalConversion(table: Table): Table {
     } else {
       listFields = table.schema.fields.filter(
         (f) =>
-          f.type.toString().startsWith('List<') || f.type.toString() === 'List',
+          f.type.toString().startsWith('List<') || f.type.toString() === 'List'
       );
       structFields = table.schema.fields.filter(
         (f) =>
           f.type.toString().startsWith('Struct<') ||
-          f.type.toString() === 'Struct',
+          f.type.toString() === 'Struct'
       );
     }
 
@@ -362,7 +362,7 @@ function wrapTableForDecimalConversion(table: Table): Table {
         if (value !== null && value !== undefined) {
           // Find corresponding field in original schema
           const originalField = originalSchema?.find(
-            (f: any) => f.name === field.name,
+            (f: any) => f.name === field.name
           );
 
           // If value is a JSON string, parse it first, convert timestamps, then stringify back
@@ -429,7 +429,7 @@ export class SpiceClient {
     params: string | SpiceClientConfig = {},
     platform: PlatformAdapter,
     retry: RetryModule,
-    GrpcClientClass?: typeof GrpcFlightClient,
+    GrpcClientClass?: typeof GrpcFlightClient
   ) {
     this._retry = retry;
     this._maxRetries = retry.FLIGHT_QUERY_MAX_RETRIES;
@@ -490,7 +490,7 @@ export class SpiceClient {
         this._apiKey,
         this._flightUrl,
         this._userAgent,
-        this._flightTlsEnabled,
+        this._flightTlsEnabled
       );
     }
 
@@ -529,7 +529,9 @@ export class SpiceClient {
 
     if (this._grpcClient && this._flightUrl) {
       configLines.push(
-        `   Flight URL: ${this._flightUrl}${this._flightTlsEnabled ? ' (TLS)' : ''}`,
+        `   Flight URL: ${this._flightUrl}${
+          this._flightTlsEnabled ? ' (TLS)' : ''
+        }`
       );
     }
 
@@ -539,7 +541,9 @@ export class SpiceClient {
 
     if (this._customHeaders && Object.keys(this._customHeaders).length > 0) {
       configLines.push(
-        `   Custom Headers: ${Object.keys(this._customHeaders).length} header(s)`,
+        `   Custom Headers: ${
+          Object.keys(this._customHeaders).length
+        } header(s)`
       );
     }
 
@@ -548,7 +552,7 @@ export class SpiceClient {
 
   private async doQueryRequest(
     queryText: string,
-    onData: ((data: Table) => void) | undefined = undefined,
+    onData: ((data: Table) => void) | undefined = undefined
   ): Promise<Table> {
     // Try gRPC if available
     if (this._grpcClient) {
@@ -560,7 +564,7 @@ export class SpiceClient {
       // If flightOnly mode is enabled and gRPC failed, throw error
       if (this._flightOnly) {
         throw new Error(
-          'gRPC Arrow Flight connection failed and flightOnly mode is enabled. Cannot fallback to HTTP.',
+          'gRPC Arrow Flight connection failed and flightOnly mode is enabled. Cannot fallback to HTTP.'
         );
       }
     }
@@ -568,7 +572,7 @@ export class SpiceClient {
     // If flightOnly mode is enabled but no gRPC client, throw error
     if (this._flightOnly) {
       throw new Error(
-        'flightOnly mode is enabled but gRPC client is not available on this platform',
+        'flightOnly mode is enabled but gRPC client is not available on this platform'
       );
     }
 
@@ -578,7 +582,7 @@ export class SpiceClient {
 
   private async doGrpcQueryRequest(
     queryText: string,
-    onData: ((data: Table) => void) | undefined = undefined,
+    onData: ((data: Table) => void) | undefined = undefined
   ): Promise<Table> {
     if (!this._grpcClient) {
       throw new Error('gRPC client not initialized');
@@ -601,7 +605,7 @@ export class SpiceClient {
         } else if (onData) {
           isDataAlreadySent = true;
           const chunkTable = wrapTableForDecimalConversion(
-            tableFromIPC([schema, ipcMessage]),
+            tableFromIPC([schema, ipcMessage])
           );
           onData(chunkTable);
         }
@@ -627,7 +631,7 @@ export class SpiceClient {
 
   private async doHttpQueryRequest(
     queryText: string,
-    onData: ((data: Table) => void) | undefined = undefined,
+    onData: ((data: Table) => void) | undefined = undefined
   ): Promise<Table> {
     // Use appropriate Accept header based on endpoint (use cached value)
     const acceptHeader = this._isSpiceCloud
@@ -642,13 +646,13 @@ export class SpiceClient {
       {
         'Content-Type': 'text/plain',
         Accept: acceptHeader,
-      },
+      }
     );
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(
-        `HTTP query failed with status ${response.status}: ${errorText}`,
+        `HTTP query failed with status ${response.status}: ${errorText}`
       );
     }
 
@@ -672,7 +676,7 @@ export class SpiceClient {
   private parseStreamingResponse(
     lines: string[],
     onData: ((data: Table) => void) | undefined,
-    isSpiceAI: boolean,
+    isSpiceAI: boolean
   ): Table {
     const allRows: any[] = [];
     let schema: any[] = [];
@@ -694,7 +698,7 @@ export class SpiceClient {
           // Send partial results if callback provided
           if (onData) {
             const partialTable = wrapTableForDecimalConversion(
-              jsonToArrowTable(schema, sqlV1.data),
+              jsonToArrowTable(schema, sqlV1.data)
             );
             onData(partialTable);
           }
@@ -710,7 +714,7 @@ export class SpiceClient {
   private parseSingleResponse(
     body: string,
     onData: ((data: Table) => void) | undefined,
-    isSpiceAI: boolean,
+    isSpiceAI: boolean
   ): Table {
     try {
       const jsonData = JSON.parse(body);
@@ -727,7 +731,9 @@ export class SpiceClient {
       return wrapTableForDecimalConversion(jsonToArrowTable(schema, rows));
     } catch (error) {
       throw new Error(
-        `Failed to parse query response: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Failed to parse query response: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
       );
     }
   }
@@ -740,11 +746,11 @@ export class SpiceClient {
    */
   async sql(
     queryText: string,
-    onData?: ((data: Table) => void) | undefined,
+    onData?: ((data: Table) => void) | undefined
   ): Promise<Table> {
     return this._retry.retryWithExponentialBackoff<Table>(
       () => this.doQueryRequest(queryText, onData),
-      this._maxRetries,
+      this._maxRetries
     );
   }
 
@@ -753,7 +759,7 @@ export class SpiceClient {
    */
   async query(
     queryText: string,
-    onData?: ((data: Table) => void) | undefined,
+    onData?: ((data: Table) => void) | undefined
   ): Promise<Table> {
     return this.sql(queryText, onData);
   }
@@ -775,7 +781,7 @@ export class SpiceClient {
       // If flightOnly mode is enabled and gRPC failed, throw error
       if (!useGrpc && this._flightOnly) {
         throw new Error(
-          'gRPC Arrow Flight connection failed and flightOnly mode is enabled. Cannot fallback to HTTP.',
+          'gRPC Arrow Flight connection failed and flightOnly mode is enabled. Cannot fallback to HTTP.'
         );
       }
     }
@@ -783,7 +789,7 @@ export class SpiceClient {
     // If flightOnly mode is enabled but no gRPC client, throw error
     if (this._flightOnly && !useGrpc) {
       throw new Error(
-        'flightOnly mode is enabled but gRPC client is not available on this platform',
+        'flightOnly mode is enabled but gRPC client is not available on this platform'
       );
     }
 
@@ -798,7 +804,7 @@ export class SpiceClient {
         if (!schema) {
           schema = {
             fields: table.schema.fields.map((field) =>
-              serializeArrowField(field),
+              serializeArrowField(field)
             ),
           };
           fields = table.schema.fields;
@@ -898,7 +904,7 @@ export class SpiceClient {
               if (childField.name in value) {
                 result[childField.name] = convertValue(
                   value[childField.name],
-                  childField,
+                  childField
                 );
               }
             }
@@ -953,13 +959,13 @@ export class SpiceClient {
         {
           'Content-Type': 'text/plain',
           Accept: 'application/vnd.spiceai.sql.v1+json',
-        },
+        }
       );
 
       if (!response.ok) {
         const errorText = await response.text();
         throw new Error(
-          `HTTP query failed with status ${response.status}: ${errorText}`,
+          `HTTP query failed with status ${response.status}: ${errorText}`
         );
       }
 
@@ -1117,13 +1123,13 @@ export class SpiceClient {
       'POST',
       '/v1/nsql',
       undefined,
-      JSON.stringify(request),
+      JSON.stringify(request)
     );
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(
-        `NSQL request failed: ${response.status} ${response.statusText} - ${errorText}`,
+        `NSQL request failed: ${response.status} ${response.statusText} - ${errorText}`
       );
     }
 
@@ -1151,7 +1157,7 @@ export class SpiceClient {
    */
   async refreshAcceleration(
     dataset: string,
-    options?: RefreshAccelerationOptions,
+    options?: RefreshAccelerationOptions
   ): Promise<RefreshAccelerationResponse> {
     if (!this._httpUrl) {
       throw new Error('HTTP URL is required for refresh operation');
@@ -1163,13 +1169,13 @@ export class SpiceClient {
       'POST',
       `/v1/datasets/${encodeURIComponent(dataset)}/acceleration/refresh`,
       undefined,
-      body,
+      body
     );
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(
-        `Failed to refresh dataset '${dataset}': ${response.status} ${response.statusText} - ${errorText}`,
+        `Failed to refresh dataset '${dataset}': ${response.status} ${response.statusText} - ${errorText}`
       );
     }
 
@@ -1240,7 +1246,7 @@ export class SpiceClient {
     path: string,
     params?: { [key: string]: string },
     body?: string,
-    customHeaders?: { [key: string]: string },
+    customHeaders?: { [key: string]: string }
   ) {
     const url =
       params && Object.keys(params).length

--- a/src/client.ts
+++ b/src/client.ts
@@ -127,7 +127,7 @@ function loadProtoFromContent(content: string): any {
     const arrow = grpc.loadPackageDefinition(packageDefinition).arrow as any;
     return arrow.flight.protocol;
   } catch (error: any) {
-    console.error(
+    console.log(
       '[spice.js] Failed to load proto from content:',
       error.message,
     );

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,7 +47,7 @@ const PROTO_DOWNLOAD_URL =
 const PACKAGE_PATH = __dirname.includes('.next')
   ? path.join(
       __dirname.substring(0, __dirname.indexOf('.next')),
-      './node_modules/@spiceai/spice/',
+      './node_modules/@spiceai/spice/'
     )
   : __dirname;
 const fullProtoPath = path.join(PACKAGE_PATH, PROTO_PATH);
@@ -65,7 +65,7 @@ async function downloadProtoFile(): Promise<string> {
 
     if (!response.ok) {
       throw new Error(
-        `Failed to download proto: ${response.status} ${response.statusText}`,
+        `Failed to download proto: ${response.status} ${response.statusText}`
       );
     }
 
@@ -90,7 +90,7 @@ async function loadProtoContent(): Promise<string | null> {
   }
 
   console.warn(
-    '[spice.js] Local Flight.proto not found, attempting to download...',
+    '[spice.js] Local Flight.proto not found, attempting to download...'
   );
 
   // Try to download
@@ -127,13 +127,11 @@ function loadProtoFromContent(content: string): any {
     const arrow = grpc.loadPackageDefinition(packageDefinition).arrow as any;
     return arrow.flight.protocol;
   } catch (error: any) {
-    console.log(
-      '[spice.js] Failed to load proto from content:',
-      error.message,
-    );
+    console.log('[spice.js] Failed to load proto from content:', error.message);
     throw error;
   }
-} /**
+}
+/**
  * Initialize the proto file (sync attempt)
  */
 function initializeProto(): void {
@@ -239,7 +237,7 @@ class SpiceClient {
       this._useGrpc = true;
     } catch (error: any) {
       console.warn(
-        `[spice.js] gRPC initialization failed: ${error.message}. Using HTTP endpoint.`,
+        `[spice.js] gRPC initialization failed: ${error.message}. Using HTTP endpoint.`
       );
       this._useGrpc = false;
     }
@@ -268,7 +266,7 @@ class SpiceClient {
       return new flightProto.FlightService(
         this._flightUrl,
         grpc.credentials.createInsecure(),
-        channelOptions,
+        channelOptions
       );
     }
 
@@ -280,18 +278,18 @@ class SpiceClient {
       grpc.credentials.createFromMetadataGenerator(metaCallback);
     const combCreds = grpc.credentials.combineChannelCredentials(
       creds,
-      callCreds,
+      callCreds
     );
     return new flightProto.FlightService(
       this._flightUrl,
       combCreds,
-      channelOptions,
+      channelOptions
     );
   }
 
   private async getResultStream(
     queryText: string,
-    getFlightClient: ((client: FlightClient) => void) | undefined = undefined,
+    getFlightClient: ((client: FlightClient) => void) | undefined = undefined
   ): Promise<EventEmitter> {
     const meta = new grpc.Metadata();
     meta.set('authorization', `Bearer ${this._apiKey || ''}`);
@@ -318,7 +316,7 @@ class SpiceClient {
             return;
           }
           resolve(result.endpoint[0].ticket);
-        },
+        }
       );
     });
 
@@ -337,7 +335,7 @@ class SpiceClient {
    */
   async sql(
     queryText: string,
-    onData?: ((data: Table) => void) | undefined,
+    onData?: ((data: Table) => void) | undefined
   ): Promise<Table> {
     return this.doQueryRequest(queryText, onData);
   }
@@ -347,7 +345,7 @@ class SpiceClient {
    */
   async query(
     queryText: string,
-    onData?: ((data: Table) => void) | undefined,
+    onData?: ((data: Table) => void) | undefined
   ): Promise<Table> {
     return this.sql(queryText, onData);
   }
@@ -367,7 +365,7 @@ class SpiceClient {
       if (!schema) {
         schema = {
           fields: table.schema.fields.map((field) =>
-            serializeArrowField(field),
+            serializeArrowField(field)
           ),
         };
       }
@@ -420,13 +418,13 @@ class SpiceClient {
       'POST',
       '/v1/nsql',
       undefined,
-      JSON.stringify(request),
+      JSON.stringify(request)
     );
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(
-        `NSQL request failed: ${response.status} ${response.statusText} - ${errorText}`,
+        `NSQL request failed: ${response.status} ${response.statusText} - ${errorText}`
       );
     }
 
@@ -436,7 +434,7 @@ class SpiceClient {
 
   private async doQueryRequest(
     queryText: string,
-    onData: ((data: Table) => void) | undefined = undefined,
+    onData: ((data: Table) => void) | undefined = undefined
   ): Promise<Table> {
     // Wait for initialization to complete
     const useGrpc = await this.ensureInitialized();
@@ -446,7 +444,7 @@ class SpiceClient {
       // Convert SqlJsonResponse to Arrow Table
       return jsonToArrowTable(
         sqlJsonResponse.schema.fields,
-        sqlJsonResponse.data,
+        sqlJsonResponse.data
       );
     }
 
@@ -457,7 +455,7 @@ class SpiceClient {
         queryText,
         (c: FlightClient) => {
           client = c;
-        },
+        }
       );
 
       // indicates that data has been partially or fully sent
@@ -500,7 +498,7 @@ class SpiceClient {
 
   private async doHttpQueryRequest(
     queryText: string,
-    onData: ((data: Table) => void) | undefined = undefined,
+    onData: ((data: Table) => void) | undefined = undefined
   ): Promise<SqlV1JsonResponse> {
     const startTime = Date.now();
 
@@ -509,13 +507,13 @@ class SpiceClient {
       '/v1/sql',
       undefined,
       JSON.stringify({ sql: queryText, parameters: [] }),
-      { Accept: 'application/vnd.spiceai.sql.v1+json' },
+      { Accept: 'application/vnd.spiceai.sql.v1+json' }
     );
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(
-        `HTTP query failed with status ${response.status}: ${errorText}`,
+        `HTTP query failed with status ${response.status}: ${errorText}`
       );
     }
 
@@ -571,7 +569,7 @@ class SpiceClient {
    */
   async refreshAcceleration(
     dataset: string,
-    options?: RefreshAccelerationOptions,
+    options?: RefreshAccelerationOptions
   ): Promise<RefreshAccelerationResponse> {
     if (!this._httpUrl) {
       throw new Error('HTTP URL is required for refresh operation');
@@ -583,13 +581,13 @@ class SpiceClient {
       'POST',
       `/v1/datasets/${encodeURIComponent(dataset)}/acceleration/refresh`,
       undefined,
-      body,
+      body
     );
 
     if (!response.ok) {
       const errorText = await response.text();
       throw new Error(
-        `Failed to refresh dataset '${dataset}': ${response.status} ${response.statusText} - ${errorText}`,
+        `Failed to refresh dataset '${dataset}': ${response.status} ${response.statusText} - ${errorText}`
       );
     }
 
@@ -601,7 +599,7 @@ class SpiceClient {
     path: string,
     params?: { [key: string]: string },
     body?: string,
-    customHeaders?: { [key: string]: string },
+    customHeaders?: { [key: string]: string }
   ) {
     const url =
       params && Object.keys(params).length

--- a/src/grpc/client.node.ts
+++ b/src/grpc/client.node.ts
@@ -102,7 +102,7 @@ function loadProtoFromContent(content: string): any {
     const arrow = grpc.loadPackageDefinition(packageDefinition).arrow as any;
     return arrow.flight.protocol;
   } catch (error: any) {
-    console.error(
+    console.log(
       '[spice.js] Failed to load proto from content:',
       error.message
     );

--- a/src/grpc/client.node.ts
+++ b/src/grpc/client.node.ts
@@ -102,10 +102,7 @@ function loadProtoFromContent(content: string): any {
     const arrow = grpc.loadPackageDefinition(packageDefinition).arrow as any;
     return arrow.flight.protocol;
   } catch (error: any) {
-    console.log(
-      '[spice.js] Failed to load proto from content:',
-      error.message
-    );
+    console.log('[spice.js] Failed to load proto from content:', error.message);
     throw error;
   }
 }


### PR DESCRIPTION
This pull request addresses a bug where timestamps could incorrectly end up with a double 'Z' suffix (e.g., `2025-10-03T18:56:10.790ZZ`) during timezone conversions. The main change ensures that a 'Z' is only appended if it's not already present. The update also adds comprehensive tests to prevent regressions and includes minor code style improvements.

**Bug Fixes:**

* Prevents appending a second 'Z' to ISO timestamp strings if one is already present, fixing the "double Z" bug in all relevant timestamp conversion code paths. [[1]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L326-R327) [[2]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L338-R339) [[3]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L846-R853) [[4]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L864-R871)

**Testing Improvements:**

* Adds new test cases to verify that timestamps, including those with non-zero milliseconds and those in nested structures, never receive a double 'Z' suffix. Tests also cover `sqlJson` responses.

**Code Quality:**

* Cleans up function signatures and object formatting for consistency, such as removing unnecessary trailing commas and improving multi-line string formatting. [[1]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L30-R30) [[2]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L207-R207) [[3]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L242-R242) [[4]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L262-R267) [[5]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L365-R365) [[6]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L432-R432) [[7]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L493-R493) [[8]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L532-R534) [[9]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L542-R546) [[10]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L551-R555) [[11]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L563-R575) [[12]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L581-R585) [[13]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L604-R608) [[14]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L630-R634) [[15]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L645-R655) [[16]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L675-R679) [[17]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L697-R701) [[18]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L713-R717) [[19]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L730-R736) [[20]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L743-R753) [[21]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L756-R762) [[22]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L778-R792) [[23]](diffhunk://#diff-d5b3f88aa9d0878921b8f2c51a1c3ee46cc38f57e1ad8c35c4fa0ec8e4202ab1L801-R807)

**Testing Infrastructure:**

* Updates test setup to match new code style and ensures mock dependencies are correctly passed.