### PR TITLE
Upgrade Next & React

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@spiceai/spice",
-  "version": "3.0.3",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@spiceai/spice",
-      "version": "3.0.3",
+      "version": "3.0.5",
       "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "^2.6.12",
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1267,9 +1267,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4148,15 +4148,15 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
@@ -4864,9 +4864,9 @@
       }
     },
     "node_modules/jest-config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5252,9 +5252,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5497,9 +5497,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5858,11 +5858,11 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/brace-expansion": "^5.0.0"
       },

--- a/test/apps/vercel-nextjs/package-lock.json
+++ b/test/apps/vercel-nextjs/package-lock.json
@@ -10,12 +10,12 @@
             "dependencies": {
                 "@spiceai/spice": "file:../../../",
                 "@types/node": "^22.0.0",
-                "@types/react": "^19.2.0",
-                "@types/react-dom": "^19.0.0",
+                "@types/react": "^19.2.7",
+                "@types/react-dom": "^19.2.3",
                 "diff": "^8.0.2",
-                "next": "^15.0.0",
-                "react": "^19.0.0",
-                "react-dom": "^19.0.0",
+                "next": "^16.0.8",
+                "react": "^19.2.1",
+                "react-dom": "^19.2.1",
                 "typescript": "^5.7.0"
             },
             "devDependencies": {
@@ -24,7 +24,7 @@
         },
         "../../..": {
             "name": "@spiceai/spice",
-            "version": "3.0.2",
+            "version": "3.0.5",
             "license": "MIT",
             "dependencies": {
                 "@types/node-fetch": "^2.6.12",
@@ -496,15 +496,15 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.4.tgz",
-            "integrity": "sha512-27SQhYp5QryzIT5uO8hq99C69eLQ7qkzkDPsk3N+GuS2XgOgoYEeOav7Pf8Tn4drECOVDsDg8oj+/DVy8qQL2A==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-16.0.8.tgz",
+            "integrity": "sha512-xP4WrQZuj9MdmLJy3eWFHepo+R3vznsMSS8Dy3wdA7FKpjCiesQ6DxZvdGziQisj0tEtCgBKJzjcAc4yZOgLEQ==",
             "license": "MIT"
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.4.tgz",
-            "integrity": "sha512-nopqz+Ov6uvorej8ndRX6HlxCYWCO3AHLfKK2TYvxoSB2scETOcfm/HSS3piPqc3A+MUgyHoqE6je4wnkjfrOA==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.0.8.tgz",
+            "integrity": "sha512-yjVMvTQN21ZHOclQnhSFbjBTEizle+1uo4NV6L4rtS9WO3nfjaeJYw+H91G+nEf3Ef43TaEZvY5mPWfB/De7tA==",
             "cpu": [
                 "arm64"
             ],
@@ -518,9 +518,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.4.tgz",
-            "integrity": "sha512-QOTCFq8b09ghfjRJKfb68kU9k2K+2wsC4A67psOiMn849K9ZXgCSRQr0oVHfmKnoqCbEmQWG1f2h1T2vtJJ9mA==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.0.8.tgz",
+            "integrity": "sha512-+zu2N3QQ0ZOb6RyqQKfcu/pn0UPGmg+mUDqpAAEviAcEVEYgDckemOpiMRsBP3IsEKpcoKuNzekDcPczEeEIzA==",
             "cpu": [
                 "x64"
             ],
@@ -534,9 +534,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.4.tgz",
-            "integrity": "sha512-eRD5zkts6jS3VfE/J0Kt1VxdFqTnMc3QgO5lFE5GKN3KDI/uUpSyK3CjQHmfEkYR4wCOl0R0XrsjpxfWEA++XA==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.0.8.tgz",
+            "integrity": "sha512-LConttk+BeD0e6RG0jGEP9GfvdaBVMYsLJ5aDDweKiJVVCu6sGvo+Ohz9nQhvj7EQDVVRJMCGhl19DmJwGr6bQ==",
             "cpu": [
                 "arm64"
             ],
@@ -550,9 +550,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.4.tgz",
-            "integrity": "sha512-TOK7iTxmXFc45UrtKqWdZ1shfxuL4tnVAOuuJK4S88rX3oyVV4ZkLjtMT85wQkfBrOOvU55aLty+MV8xmcJR8A==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.0.8.tgz",
+            "integrity": "sha512-JaXFAlqn8fJV+GhhA9lpg6da/NCN/v9ub98n3HoayoUSPOVdoxEEt86iT58jXqQCs/R3dv5ZnxGkW8aF4obMrQ==",
             "cpu": [
                 "arm64"
             ],
@@ -566,9 +566,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.4.tgz",
-            "integrity": "sha512-7HKolaj+481FSW/5lL0BcTkA4Ueam9SPYWyN/ib/WGAFZf0DGAN8frNpNZYFHtM4ZstrHZS3LY3vrwlIQfsiMA==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.0.8.tgz",
+            "integrity": "sha512-O7M9it6HyNhsJp3HNAsJoHk5BUsfj7hRshfptpGcVsPZ1u0KQ/oVy8oxF7tlwxA5tR43VUP0yRmAGm1us514ng==",
             "cpu": [
                 "x64"
             ],
@@ -582,9 +582,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.4.tgz",
-            "integrity": "sha512-nlQQ6nfgN0nCO/KuyEUwwOdwQIGjOs4WNMjEUtpIQJPR2NUfmGpW2wkJln1d4nJ7oUzd1g4GivH5GoEPBgfsdw==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.0.8.tgz",
+            "integrity": "sha512-8+KClEC/GLI2dLYcrWwHu5JyC5cZYCFnccVIvmxpo6K+XQt4qzqM5L4coofNDZYkct/VCCyJWGbZZDsg6w6LFA==",
             "cpu": [
                 "x64"
             ],
@@ -598,9 +598,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.4.tgz",
-            "integrity": "sha512-PcR2bN7FlM32XM6eumklmyWLLbu2vs+D7nJX8OAIoWy69Kef8mfiN4e8TUv2KohprwifdpFKPzIP1njuCjD0YA==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.0.8.tgz",
+            "integrity": "sha512-rpQ/PgTEgH68SiXmhu/cJ2hk9aZ6YgFvspzQWe2I9HufY6g7V02DXRr/xrVqOaKm2lenBFPNQ+KAaeveywqV+A==",
             "cpu": [
                 "arm64"
             ],
@@ -614,9 +614,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.4.tgz",
-            "integrity": "sha512-1ur2tSHZj8Px/KMAthmuI9FMp/YFusMMGoRNJaRZMOlSkgvLjzosSdQI0cJAKogdHl3qXUQKL9MGaYvKwA7DXg==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.0.8.tgz",
+            "integrity": "sha512-jWpWjWcMQu2iZz4pEK2IktcfR+OA9+cCG8zenyLpcW8rN4rzjfOzH4yj/b1FiEAZHKS+5Vq8+bZyHi+2yqHbFA==",
             "cpu": [
                 "x64"
             ],
@@ -659,18 +659,18 @@
             }
         },
         "node_modules/@types/react": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
-            "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+            "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
             "dependencies": {
-                "csstype": "^3.0.2"
+                "csstype": "^3.2.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.0.tgz",
-            "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -703,9 +703,9 @@
             "license": "MIT"
         },
         "node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+            "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
             "license": "MIT"
         },
         "node_modules/detect-libc": {
@@ -746,12 +746,12 @@
             }
         },
         "node_modules/next": {
-            "version": "15.5.4",
-            "resolved": "https://registry.npmjs.org/next/-/next-15.5.4.tgz",
-            "integrity": "sha512-xH4Yjhb82sFYQfY3vbkJfgSDgXvBB6a8xPs9i35k6oZJRoQRihZH+4s9Yo2qsWpzBmZ3lPXaJ2KPXLfkvW4LnA==",
+            "version": "16.0.8",
+            "resolved": "https://registry.npmjs.org/next/-/next-16.0.8.tgz",
+            "integrity": "sha512-LmcZzG04JuzNXi48s5P+TnJBsTGPJunViNKV/iE4uM6kstjTQsQhvsAv+xF6MJxU2Pr26tl15eVbp0jQnsv6/g==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "15.5.4",
+                "@next/env": "16.0.8",
                 "@swc/helpers": "0.5.15",
                 "caniuse-lite": "^1.0.30001579",
                 "postcss": "8.4.31",
@@ -761,18 +761,18 @@
                 "next": "dist/bin/next"
             },
             "engines": {
-                "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+                "node": ">=20.9.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "15.5.4",
-                "@next/swc-darwin-x64": "15.5.4",
-                "@next/swc-linux-arm64-gnu": "15.5.4",
-                "@next/swc-linux-arm64-musl": "15.5.4",
-                "@next/swc-linux-x64-gnu": "15.5.4",
-                "@next/swc-linux-x64-musl": "15.5.4",
-                "@next/swc-win32-arm64-msvc": "15.5.4",
-                "@next/swc-win32-x64-msvc": "15.5.4",
-                "sharp": "^0.34.3"
+                "@next/swc-darwin-arm64": "16.0.8",
+                "@next/swc-darwin-x64": "16.0.8",
+                "@next/swc-linux-arm64-gnu": "16.0.8",
+                "@next/swc-linux-arm64-musl": "16.0.8",
+                "@next/swc-linux-x64-gnu": "16.0.8",
+                "@next/swc-linux-x64-musl": "16.0.8",
+                "@next/swc-win32-arm64-msvc": "16.0.8",
+                "@next/swc-win32-x64-msvc": "16.0.8",
+                "sharp": "^0.34.4"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -832,24 +832,24 @@
             }
         },
         "node_modules/react": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-            "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+            "version": "19.2.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
+            "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-            "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+            "version": "19.2.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
+            "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.0"
+                "react": "^19.2.1"
             }
         },
         "node_modules/scheduler": {

--- a/test/apps/vercel-nextjs/package.json
+++ b/test/apps/vercel-nextjs/package.json
@@ -12,12 +12,12 @@
     "dependencies": {
         "@spiceai/spice": "file:../../../",
         "@types/node": "^22.0.0",
-        "@types/react": "^19.2.0",
-        "@types/react-dom": "^19.0.0",
+        "@types/react": "^19.2.7",
+        "@types/react-dom": "^19.2.3",
         "diff": "^8.0.2",
-        "next": "^15.0.0",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "next": "^16.0.8",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
         "typescript": "^5.7.0"
     },
     "devDependencies": {

--- a/test/apps/vercel-nextjs/package.json
+++ b/test/apps/vercel-nextjs/package.json
@@ -15,9 +15,9 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "diff": "^8.0.2",
-        "next": "^16.0.8",
-        "react": "^19.2.1",
-        "react-dom": "^19.2.1",
+        "next": "^16.0.10",
+        "react": "^19.2.3",
+        "react-dom": "^19.2.3",
         "typescript": "^5.7.0"
     },
     "devDependencies": {


### PR DESCRIPTION
This pull request updates the dependencies for the Vercel Next.js test app, primarily to bring in the latest versions of Next.js, React, and their related type definitions. These updates ensure compatibility with newer features, bug fixes, and improved stability. The changes affect both `package.json` and `package-lock.json`.

**Dependency version upgrades:**

* Upgraded `next` to `^16.0.8`, including all platform-specific SWC packages and updated the minimum required Node.js version to `>=20.9.0`. [[1]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL13-R18) [[2]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL499-R507) [[3]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL521-R523) [[4]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL537-R539) [[5]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL553-R555) [[6]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL569-R571) [[7]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL585-R587) [[8]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL601-R603) [[9]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL617-R619) [[10]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL749-R754) [[11]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL764-R775)
* Upgraded `react` and `react-dom` to `^19.2.1` for both runtime and type definitions, ensuring alignment between code and types. [[1]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL13-R18) [[2]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL662-R673) [[3]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL835-R852) [[4]](diffhunk://#diff-2e7c6e95b014c069000c7238ce6bbf649e759b5ed9a40f281ce00be2871810e5L15-R20)
* Upgraded `@types/react` to `^19.2.7` and `@types/react-dom` to `^19.2.3` to match the new React versions. [[1]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL13-R18) [[2]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL662-R673) [[3]](diffhunk://#diff-2e7c6e95b014c069000c7238ce6bbf649e759b5ed9a40f281ce00be2871810e5L15-R20)
* Updated `csstype` dependency to `^3.2.2` and resolved version to `3.2.3` for improved type support. [[1]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL662-R673) [[2]](diffhunk://#diff-8dfb58519b463969a84525291cc805f4d5995b6fe6a45b4f098dbf3c0b739d5cL706-R708)
* Updated internal `@spiceai/spice` dependency to version `3.0.5`.