### PR TITLE
Add configurable logging for spice.js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,3 @@
 [*]
 quote_type = single
+trailing_comma = all

--- a/.github/actions/setup-vercel-endpoint/action.yml
+++ b/.github/actions/setup-vercel-endpoint/action.yml
@@ -44,8 +44,8 @@ runs:
           echo "Detected tag/release: ${BRANCH_NAME}, using production endpoint"
         else
           # For branches, construct the git branch preview URL
-          # Remove periods, replace / with - and convert to lowercase for Vercel format
-          BRANCH_SLUG=$(echo "$BRANCH_NAME" | sed 's/\.//g' | sed 's/\//-/g' | tr '[:upper:]' '[:lower:]')
+          # Remove periods, replace first / with -, remove remaining /, convert to lowercase for Vercel format
+          BRANCH_SLUG=$(echo "$BRANCH_NAME" | sed 's/\.//g' | sed 's/\//-/' | sed 's/\///g' | tr '[:upper:]' '[:lower:]')
           VERCEL_ENDPOINT="https://spice-js-git-${BRANCH_SLUG}-spice.vercel.app"
           echo "Detected branch: ${BRANCH_NAME}, using preview endpoint"
         fi

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "semi": true,
+  "arrowParens": "always"
+}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Querying data is done through a `SpiceClient` object that initializes the connec
 - `apiKey` (string, optional): API key to authenticate with the endpoint.
 - `flightUrl` (string, optional): URL of the Flight endpoint to use (default: `localhost:50051`)
 - `httpUrl` (string, optional): URL of the HTTP endpoint to use (default: `http://localhost:8090`)
+- `logging` (boolean, optional): Enable or disable logging output (default: `true`). Set to `false` to silence all library console output.
 
 Read more about the Spice.ai Apache Arrow Flight API at [docs.spice.ai](https://docs.spice.ai/api/sql-query-api/apache-arrow-flight-api).
 

--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -22,6 +22,7 @@ import {
   normalizeSchema,
   serializeArrowField,
 } from './arrow-utils';
+import { Logger } from './logger';
 
 // Retry will be imported by the platform-specific entry point
 export interface RetryModule {
@@ -426,6 +427,7 @@ export class SpiceClient {
   private _retry: RetryModule;
   private _isSpiceCloud: boolean = false;
   private _flightOnly: boolean = false;
+  private _logger: Logger;
 
   public constructor(
     params: string | SpiceClientConfig = {},
@@ -444,6 +446,7 @@ export class SpiceClient {
       this._flightUrl = 'flight.spiceai.io:443';
       this._userAgent = platform.getUserAgent();
       this._flightOnly = false;
+      this._logger = new Logger(true); // Default: logging enabled
     } else {
       const {
         apiKey,
@@ -453,7 +456,11 @@ export class SpiceClient {
         userAgent,
         customHeaders,
         flightOnly,
+        logging,
       } = params;
+
+      // Initialize logger (default: enabled)
+      this._logger = new Logger(logging !== false);
 
       this._apiKey = apiKey;
       this._httpUrl = httpUrl || 'http://127.0.0.1:8090';
@@ -493,6 +500,7 @@ export class SpiceClient {
         this._flightUrl,
         this._userAgent,
         this._flightTlsEnabled,
+        this._logger,
       );
     }
 
@@ -549,7 +557,7 @@ export class SpiceClient {
       );
     }
 
-    console.debug(configLines.join('\n'));
+    this._logger.debug(configLines.join('\n'));
   }
 
   private async doQueryRequest(
@@ -719,7 +727,9 @@ export class SpiceClient {
           }
         }
       } catch (parseError) {
-        console.warn(`[spice.js] Failed to parse JSON line: ${parseError}`);
+        this._logger.warn(
+          `[spice.js] Failed to parse JSON line: ${parseError}`,
+        );
       }
     }
 

--- a/src/grpc/client.node.ts
+++ b/src/grpc/client.node.ts
@@ -10,6 +10,7 @@ import * as protobuf from 'protobufjs';
 import { EventEmitter } from 'stream';
 import { FlightClient, FlightInfo, DescriptorType, Ticket } from '../flight';
 import { platform } from '../platform/node';
+import { Logger } from '../logger';
 
 const PROTO_PATH = './proto/Flight.proto';
 const PROTO_DOWNLOAD_URL =
@@ -33,9 +34,9 @@ let grpcAvailable = false;
 /**
  * Downloads the Flight.proto file from the remote URL and keeps it in memory
  */
-async function downloadProtoFile(): Promise<string> {
+async function downloadProtoFile(logger?: Logger): Promise<string> {
   try {
-    console.log('[spice.js] Downloading Flight.proto from remote source...');
+    logger?.info('[spice.js] Downloading Flight.proto from remote source...');
     const response = await platform.fetch(PROTO_DOWNLOAD_URL, {
       method: 'GET',
       headers: {},
@@ -48,11 +49,11 @@ async function downloadProtoFile(): Promise<string> {
     }
 
     const content = await response.text();
-    console.log('[spice.js] Flight.proto downloaded successfully');
+    logger?.info('[spice.js] Flight.proto downloaded successfully');
 
     return content;
   } catch (error: any) {
-    console.warn(`[spice.js] Failed to download proto file: ${error.message}`);
+    logger?.warn(`[spice.js] Failed to download proto file: ${error.message}`);
     throw error;
   }
 }
@@ -61,7 +62,7 @@ async function downloadProtoFile(): Promise<string> {
  * Loads proto content from local file or downloads it
  * Returns the proto content as a string
  */
-async function loadProtoContent(): Promise<string | null> {
+async function loadProtoContent(logger?: Logger): Promise<string | null> {
   // Try local file first
   if (fs.existsSync(fullProtoPath)) {
     return fs.readFileSync(fullProtoPath, 'utf-8');
@@ -69,7 +70,7 @@ async function loadProtoContent(): Promise<string | null> {
 
   // Try to download
   try {
-    return await downloadProtoFile();
+    return await downloadProtoFile(logger);
   } catch (error) {
     return null;
   }
@@ -78,7 +79,7 @@ async function loadProtoContent(): Promise<string | null> {
 /**
  * Loads proto definition from content in memory using protobufjs
  */
-function loadProtoFromContent(content: string): any {
+function loadProtoFromContent(content: string, logger?: Logger): any {
   try {
     // Parse the proto content directly in memory using protobufjs
     const root = protobuf.parse(content, { keepCase: false }).root;
@@ -98,7 +99,10 @@ function loadProtoFromContent(content: string): any {
     const arrow = grpc.loadPackageDefinition(packageDefinition).arrow as any;
     return arrow.flight.protocol;
   } catch (error: any) {
-    console.log('[spice.js] Failed to load proto from content:', error.message);
+    logger?.info(
+      '[spice.js] Failed to load proto from content:',
+      error.message,
+    );
     throw error;
   }
 }
@@ -131,17 +135,20 @@ export class GrpcFlightClient {
   private flightTlsEnabled: boolean;
   private initPromise: Promise<void>;
   private useGrpc: boolean = grpcAvailable;
+  private logger: Logger;
 
   constructor(
     apiKey: string | undefined,
     flightUrl: string,
     userAgent: string,
     flightTlsEnabled: boolean,
+    logger?: Logger,
   ) {
     this.apiKey = apiKey;
     this.flightUrl = flightUrl;
     this.userAgent = userAgent;
     this.flightTlsEnabled = flightTlsEnabled;
+    this.logger = logger || new Logger(true);
     this.initPromise = this.initialize();
   }
 
@@ -157,7 +164,7 @@ export class GrpcFlightClient {
     try {
       // Check if we already have proto content in memory
       if (!protoContent) {
-        protoContent = await loadProtoContent();
+        protoContent = await loadProtoContent(this.logger);
       }
 
       if (!protoContent) {
@@ -166,7 +173,7 @@ export class GrpcFlightClient {
       }
 
       // Load the proto from content
-      const proto = loadProtoFromContent(protoContent);
+      const proto = loadProtoFromContent(protoContent, this.logger);
 
       if (!proto?.FlightService) {
         throw new Error('Invalid proto file structure');
@@ -176,7 +183,7 @@ export class GrpcFlightClient {
       grpcAvailable = true;
       this.useGrpc = true;
     } catch (error: any) {
-      console.warn(
+      this.logger.warn(
         `[spice.js] gRPC initialization failed: ${error.message}. Using HTTP endpoint.`,
       );
       this.useGrpc = false;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,6 +11,12 @@ export interface SpiceClientConfig {
    * @default false
    */
   flightOnly?: boolean;
+  /**
+   * Enable or disable logging output from the library.
+   * When false, all console output is suppressed.
+   * @default true
+   */
+  logging?: boolean;
 }
 
 export interface SchemaField {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,73 @@
+/**
+ * Simple logger with enable/disable support for spice.js
+ *
+ * When disabled, all logging methods are no-ops.
+ * When enabled, logs are forwarded to the appropriate console methods.
+ */
+export class Logger {
+  private readonly enabled: boolean;
+
+  constructor(enabled: boolean = true) {
+    this.enabled = enabled;
+  }
+
+  /**
+   * Log debug messages (uses console.debug)
+   */
+  debug(...args: unknown[]): void {
+    if (this.enabled) {
+      console.debug(...args);
+    }
+  }
+
+  /**
+   * Log informational messages (uses console.log)
+   */
+  info(...args: unknown[]): void {
+    if (this.enabled) {
+      console.log(...args);
+    }
+  }
+
+  /**
+   * Log warning messages (uses console.warn)
+   */
+  warn(...args: unknown[]): void {
+    if (this.enabled) {
+      console.warn(...args);
+    }
+  }
+
+  /**
+   * Log error messages (uses console.error)
+   */
+  error(...args: unknown[]): void {
+    if (this.enabled) {
+      console.error(...args);
+    }
+  }
+
+  /**
+   * Log messages (alias for info, uses console.log)
+   */
+  log(...args: unknown[]): void {
+    if (this.enabled) {
+      console.log(...args);
+    }
+  }
+
+  /**
+   * Check if logging is enabled
+   */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+}
+
+/**
+ * Create a new logger instance
+ * @param enabled - Whether logging is enabled (default: true)
+ */
+export function createLogger(enabled: boolean = true): Logger {
+  return new Logger(enabled);
+}

--- a/test/browser/client.test.ts
+++ b/test/browser/client.test.ts
@@ -50,6 +50,40 @@ describe('Browser SpiceClient', () => {
       expect(debugSpy).toHaveBeenCalled();
       debugSpy.mockRestore();
     });
+
+    test('should not log when logging is disabled', () => {
+      consoleLogSpy.mockRestore();
+      const debugSpy = jest.spyOn(console, 'debug').mockImplementation();
+      const logSpy = jest.spyOn(console, 'log').mockImplementation();
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      new SpiceClient({
+        httpUrl: 'http://localhost:8090',
+        apiKey: 'test-key',
+        logging: false,
+      });
+
+      expect(debugSpy).not.toHaveBeenCalled();
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      debugSpy.mockRestore();
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+
+    test('should log when logging is explicitly enabled', () => {
+      consoleLogSpy.mockRestore();
+      const debugSpy = jest.spyOn(console, 'debug').mockImplementation();
+
+      new SpiceClient({
+        httpUrl: 'http://localhost:8090',
+        logging: true,
+      });
+
+      expect(debugSpy).toHaveBeenCalled();
+      debugSpy.mockRestore();
+    });
     test('should create client with API key', () => {
       const apiClient = new SpiceClient({
         apiKey: 'test-api-key',
@@ -83,7 +117,7 @@ describe('Browser SpiceClient', () => {
         'http://localhost:8090/health',
         expect.objectContaining({
           method: 'GET',
-        })
+        }),
       );
     });
 
@@ -100,7 +134,7 @@ describe('Browser SpiceClient', () => {
 
     test('isSpiceHealthy should return false on network error', async () => {
       (global.fetch as jest.Mock).mockRejectedValueOnce(
-        new Error('Network error')
+        new Error('Network error'),
       );
 
       const result = await client.isSpiceHealthy();
@@ -167,7 +201,7 @@ describe('Browser SpiceClient', () => {
             // Local OSS runtime uses application/json
             Accept: 'application/json',
           }),
-        })
+        }),
       );
     });
 
@@ -302,7 +336,7 @@ describe('Browser SpiceClient', () => {
       // Verify HTTP endpoint was called
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('/v1/sql'),
-        expect.any(Object)
+        expect.any(Object),
       );
     });
 
@@ -330,7 +364,7 @@ describe('Browser SpiceClient', () => {
           headers: expect.objectContaining({
             'User-Agent': expect.stringContaining('spice.js'),
           }),
-        })
+        }),
       );
     });
   });
@@ -362,7 +396,7 @@ describe('Browser SpiceClient', () => {
         'http://localhost:8090/v1/nsql',
         expect.objectContaining({
           method: 'POST',
-        })
+        }),
       );
     });
 
@@ -413,7 +447,7 @@ describe('Browser SpiceClient', () => {
       });
 
       await expect(
-        client.refreshAcceleration('nonexistent_dataset')
+        client.refreshAcceleration('nonexistent_dataset'),
       ).rejects.toThrow();
     });
   });
@@ -457,7 +491,7 @@ describe('Browser SpiceClient', () => {
           headers: expect.objectContaining({
             'X-API-Key': 'test-api-key-123',
           }),
-        })
+        }),
       );
     });
 
@@ -510,7 +544,7 @@ describe('Browser SpiceClient', () => {
             'X-Custom-Header': 'custom-value',
             'X-Another-Header': 'another-value',
           }),
-        })
+        }),
       );
     });
   });
@@ -573,7 +607,7 @@ describe('Browser SpiceClient', () => {
         });
 
         const sqlResult = await client.sql(
-          'SELECT id, int4_column, text_column, bool_column FROM test_table ORDER BY id'
+          'SELECT id, int4_column, text_column, bool_column FROM test_table ORDER BY id',
         );
 
         // Mock for sqlJson() - returns JSON format
@@ -590,7 +624,7 @@ describe('Browser SpiceClient', () => {
         });
 
         const sqlJsonResult = await client.sqlJson(
-          'SELECT id, int4_column, text_column, bool_column FROM test_table ORDER BY id'
+          'SELECT id, int4_column, text_column, bool_column FROM test_table ORDER BY id',
         );
 
         // Convert Arrow table to array for comparison
@@ -792,7 +826,7 @@ describe('Browser SpiceClient', () => {
         expect(sqlRows[0].id).toBe(jsonRows[0].id);
         expect(typeof jsonRows[0].created_at).toBe('string');
         expect(jsonRows[0].created_at).toMatch(
-          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
         );
 
         // In HTTP mode, both should get the same timestamp string
@@ -852,7 +886,7 @@ describe('Browser SpiceClient', () => {
         });
 
         const sqlResult = await client.sql(
-          "SELECT id, value, value * 2 as doubled, CASE WHEN value > 5 THEN 'high' ELSE 'low' END as category FROM test_table"
+          "SELECT id, value, value * 2 as doubled, CASE WHEN value > 5 THEN 'high' ELSE 'low' END as category FROM test_table",
         );
 
         // Mock sqlJson()
@@ -869,7 +903,7 @@ describe('Browser SpiceClient', () => {
         });
 
         const sqlJsonResult = await client.sqlJson(
-          "SELECT id, value, value * 2 as doubled, CASE WHEN value > 5 THEN 'high' ELSE 'low' END as category FROM test_table"
+          "SELECT id, value, value * 2 as doubled, CASE WHEN value > 5 THEN 'high' ELSE 'low' END as category FROM test_table",
         );
 
         const sqlRows = sqlResult.toArray();
@@ -950,14 +984,14 @@ describe('Browser SpiceClient', () => {
 
         // Verify schema structure matches
         expect(sqlResult.schema.fields.length).toBe(
-          sqlJsonResult.schema.fields.length
+          sqlJsonResult.schema.fields.length,
         );
         expect(sqlResult.schema.fields.length).toBe(3);
 
         // Verify field names match
         const sqlFieldNames = sqlResult.schema.fields.map((f: any) => f.name);
         const jsonFieldNames = sqlJsonResult.schema.fields.map(
-          (f: any) => f.name
+          (f: any) => f.name,
         );
         expect(sqlFieldNames).toEqual(jsonFieldNames);
         expect(sqlFieldNames).toEqual(['id', 'name', 'timestamp_col']);
@@ -983,7 +1017,7 @@ describe('Browser SpiceClient', () => {
         });
 
         await expect(
-          client.sql('SELECT * FROM nonexistent_table')
+          client.sql('SELECT * FROM nonexistent_table'),
         ).rejects.toThrow();
 
         // Mock sqlJson() error
@@ -995,7 +1029,7 @@ describe('Browser SpiceClient', () => {
         });
 
         await expect(
-          client.sqlJson('SELECT * FROM nonexistent_table')
+          client.sqlJson('SELECT * FROM nonexistent_table'),
         ).rejects.toThrow();
       });
     });


### PR DESCRIPTION
## 🗣 Description

Adds a `logging` configuration option to `SpiceClient` that allows users to disable all console output from the library.

### Motivation

Users need a way to silence spice.js logging in production environments, during tests, or when integrating with their own logging infrastructure. This follows the standard pattern used by popular JS libraries like Sequelize and TypeORM.

### Changes

- Added `logging?: boolean` option to `SpiceClientConfig` (default: `true`)
- Created centralized `Logger` class in `src/logger.ts`
- Replaced all direct `console.*` calls with logger methods
- Updated gRPC client to accept and use logger instance

### Usage

```typescript
// Default behavior - logging enabled
const client = new SpiceClient({
  apiKey: 'your-api-key'
});

// Disable all logging
const client = new SpiceClient({
  apiKey: 'your-api-key',
  logging: false
});

```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
