### PR TITLE
Run only cloud.test.ts in npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,7 @@ jobs:
           branch-name: ${{ github.ref_name }}
 
       - name: Test
-        run: npm test
+        run: npm test -- test/cloud.test.ts
         timeout-minutes: 10
         env:
           SPICEAI_API_KEY: ${{ secrets.SPICEAI_API_KEY }}


### PR DESCRIPTION
## 🗣 Description

Full test suite is running on every push to trunk, we don't need to duplicate it fully in publish workflow.
Currently it fails because some tests require local spice runtime instance running.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
