### PR TITLE
Add permissions for NPM trusted publishing with OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,11 @@ on:
 
   workflow_dispatch:
 
+# Required for NPM trusted publishing with OIDC
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+    
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## 🗣 Description

configure npm trusted publishing
