### PR TITLE
SearchMatch: normalise score/_score for Spice v1/v2 compatibility

### DIFF
--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -1386,6 +1386,15 @@ export class SpiceClient {
     }
 
     const result = await response.json();
+    if (result.results) {
+      for (const match of result.results) {
+        if (match._score === undefined && match.score !== undefined) {
+          match._score = match.score;
+        } else if (match.score === undefined && match._score !== undefined) {
+          match.score = match._score;
+        }
+      }
+    }
     return result as SearchResponse;
   }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -133,9 +133,13 @@ export interface SearchMatch {
    */
   dataset: string;
   /**
-   * The similarity of the match to the query
+   * The similarity of the match to the query (Spice v1)
    */
-  score: number;
+  score?: number;
+  /**
+   * The similarity of the match to the query (Spice v2)
+   */
+  _score?: number;
   /**
    * The matches for this result
    */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -133,13 +133,20 @@ export interface SearchMatch {
    */
   dataset: string;
   /**
-   * The similarity of the match to the query (Spice v1)
+   * The similarity of the match to the query.
+   *
+   * @deprecated Use `_score` instead. This field is from Spice v1 and is kept for
+   * backward compatibility. When the server returns only `_score` (v2), this field
+   * is automatically filled from `_score`.
    */
-  score?: number;
+  score: number;
   /**
-   * The similarity of the match to the query (Spice v2)
+   * The similarity of the match to the query.
+   *
+   * This is the canonical score field used by Spice v2. When the server returns
+   * only `score` (v1), this field is automatically filled from `score`.
    */
-  _score?: number;
+  _score: number;
   /**
    * The matches for this result
    */


### PR DESCRIPTION
## Summary

Both `score` and `_score` are now always present on `SearchMatch` — the SDK fills whichever one is missing based on the server version:

| Server version | Response contains | SDK fills |
|---|---|---|
| v1 | `score` | `_score = score` |
| v2 | `_score` | `score = _score` |

`score` is marked `@deprecated` with a note to use `_score` going forward.

## Changes

- `interfaces.ts` — both fields are `number` (required), `score` has `@deprecated` JSDoc
- `client-common.ts` — normalisation applied after parsing the `/v1/search` JSON response