### PR TITLE
feat: add mTLS client certificate support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -669,7 +668,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -693,7 +691,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1846,7 +1843,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1943,7 +1939,6 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -2453,7 +2448,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2808,7 +2802,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3516,7 +3509,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4688,7 +4680,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -5495,7 +5486,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -7043,7 +7033,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7219,7 +7208,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -7306,7 +7294,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -423,6 +423,9 @@ export class SpiceClient {
   private _httpUrl: string;
   private _userAgent: string;
   private _flightTlsEnabled: boolean = true;
+  private _tlsClientCertFile?: string;
+  private _tlsClientKeyFile?: string;
+  private _tlsRootCertFile?: string;
   private _maxRetries: number;
   private _customHeaders?: { [key: string]: string };
   private _platform: PlatformAdapter;
@@ -466,6 +469,9 @@ export class SpiceClient {
         flightOnly,
         httpOnly,
         logging,
+        tlsClientCertFile,
+        tlsClientKeyFile,
+        tlsRootCertFile,
       } = params;
 
       // Initialize logger (default: enabled)
@@ -507,6 +513,9 @@ export class SpiceClient {
         ? `${userAgent} ${platform.getUserAgent()}`
         : platform.getUserAgent();
       this._customHeaders = customHeaders;
+      this._tlsClientCertFile = tlsClientCertFile;
+      this._tlsClientKeyFile = tlsClientKeyFile;
+      this._tlsRootCertFile = tlsRootCertFile;
     }
 
     // Determine if this is Spice Cloud endpoint (compute once)
@@ -526,6 +535,9 @@ export class SpiceClient {
         this._userAgent,
         this._flightTlsEnabled,
         this._logger,
+        this._tlsClientCertFile,
+        this._tlsClientKeyFile,
+        this._tlsRootCertFile,
       );
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -168,6 +168,7 @@ class SpiceClient {
   private _useGrpc: boolean = grpcAvailable;
   private _initPromise: Promise<void>;
   private _customHeaders?: { [key: string]: string };
+  private _httpsAgent: https.Agent;
 
   public constructor(params: string | SpiceClientConfig = {}) {
     // support legacy constructor with api_key as first agument
@@ -176,6 +177,7 @@ class SpiceClient {
       this._httpUrl = 'https://data.spiceai.io';
       this._flightUrl = 'flight.spiceai.io:443';
       this._userAgent = getUserAgent();
+      this._httpsAgent = new https.Agent({ keepAlive: true });
     } else {
       const {
         apiKey,
@@ -184,6 +186,9 @@ class SpiceClient {
         flightTlsEnabled,
         userAgent,
         customHeaders,
+        tlsClientCertFile,
+        tlsClientKeyFile,
+        tlsRootCertFile,
       } = params;
 
       this._apiKey = apiKey;
@@ -204,6 +209,30 @@ class SpiceClient {
         ? `${userAgent} ${getUserAgent()}`
         : getUserAgent();
       this._customHeaders = customHeaders;
+
+      // Validate that client cert and key are either both set or both unset
+      if (
+        (tlsClientCertFile && !tlsClientKeyFile) ||
+        (!tlsClientCertFile && tlsClientKeyFile)
+      ) {
+        const missing = tlsClientCertFile
+          ? 'tlsClientKeyFile'
+          : 'tlsClientCertFile';
+        throw new Error(
+          `Both tlsClientCertFile and tlsClientKeyFile must be provided together for mTLS. ${missing} is missing.`,
+        );
+      }
+
+      // Build per-instance HTTPS agent with optional mTLS certs
+      const agentOpts: https.AgentOptions = { keepAlive: true };
+      if (tlsRootCertFile) {
+        agentOpts.ca = fs.readFileSync(tlsRootCertFile);
+      }
+      if (tlsClientCertFile && tlsClientKeyFile) {
+        agentOpts.cert = fs.readFileSync(tlsClientCertFile);
+        agentOpts.key = fs.readFileSync(tlsClientKeyFile);
+      }
+      this._httpsAgent = new https.Agent(agentOpts);
     }
 
     // Initialize gRPC during construction
@@ -822,7 +851,7 @@ class SpiceClient {
     };
 
     if (this._httpUrl.startsWith('https://')) {
-      fetchOptions.agent = httpsAgent;
+      fetchOptions.agent = this._httpsAgent;
     }
 
     return fetch(url, fetchOptions);

--- a/src/grpc/client.node.ts
+++ b/src/grpc/client.node.ts
@@ -140,6 +140,10 @@ export class GrpcFlightClient {
   private initPromise: Promise<void>;
   private useGrpc: boolean = grpcAvailable;
   private logger: Logger;
+  private tlsClientCertFile?: string;
+  private tlsClientKeyFile?: string;
+
+  private tlsRootCertFile?: string;
 
   constructor(
     apiKey: string | undefined,
@@ -147,12 +151,18 @@ export class GrpcFlightClient {
     userAgent: string,
     flightTlsEnabled: boolean,
     logger?: Logger,
+    tlsClientCertFile?: string,
+    tlsClientKeyFile?: string,
+    tlsRootCertFile?: string,
   ) {
     this.apiKey = apiKey;
     this.flightUrl = flightUrl;
     this.userAgent = userAgent;
     this.flightTlsEnabled = flightTlsEnabled;
     this.logger = logger || new Logger(true);
+    this.tlsClientCertFile = tlsClientCertFile;
+    this.tlsClientKeyFile = tlsClientKeyFile;
+    this.tlsRootCertFile = tlsRootCertFile;
     this.initPromise = this.initialize();
   }
 
@@ -219,7 +229,10 @@ export class GrpcFlightClient {
       );
     }
 
-    const creds = grpc.credentials.createSsl();
+    const rootCerts = this.tlsRootCertFile ? fs.readFileSync(this.tlsRootCertFile) : null;
+    const clientCert = this.tlsClientCertFile ? fs.readFileSync(this.tlsClientCertFile) : null;
+    const clientKey = this.tlsClientKeyFile ? fs.readFileSync(this.tlsClientKeyFile) : null;
+    const creds = grpc.credentials.createSsl(rootCerts, clientKey, clientCert);
     const metaCallback = (_params: any, callback: any) => {
       callback(null, meta);
     };

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,6 +23,21 @@ export interface SpiceClientConfig {
    * @default true
    */
   logging?: boolean;
+  /**
+   * Path to a PEM-encoded CA certificate file for server verification.
+   * When set, this CA is used instead of the system certificate store.
+   */
+  tlsRootCertFile?: string;
+  /**
+   * Path to a PEM-encoded client certificate file for mTLS.
+   * Must be used together with `tlsClientKeyFile`.
+   */
+  tlsClientCertFile?: string;
+  /**
+   * Path to a PEM-encoded client private key file for mTLS.
+   * Must be used together with `tlsClientCertFile`.
+   */
+  tlsClientKeyFile?: string;
 }
 
 export interface SchemaField {


### PR DESCRIPTION
Adds mTLS (mutual TLS) client certificate support, allowing the SDK to present a client certificate during the TLS handshake when connecting to a Spice runtime with `client_auth_mode: request` or `client_auth_mode: required`.

## Usage

Provide the paths to a PEM-encoded client certificate and private key file when building the client. The certificate is presented to the server during the TLS handshake.

## Notes

- mTLS is an [Enterprise](https://docs.spice.ai/docs/enterprise) feature of the Spice runtime.
- Both the certificate and key file must be provided together.
- When not set, the client behaves exactly as before (standard TLS).
- See the [mTLS cookbook recipe](https://github.com/spiceai/cookbook/tree/trunk/mtls) for a complete walkthrough.