### PR TITLE
ci: move the test Spicepod off the removed v1beta1 version

### DIFF
--- a/test/scripts/spicepod.yaml
+++ b/test/scripts/spicepod.yaml
@@ -1,4 +1,4 @@
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test_spicejs
 datasets:


### PR DESCRIPTION
Every open PR in this repo is red on `Local Runtime`, and none of them caused it.

## Cause

`test/scripts/spicepod.yaml` still declares `version: v1beta1`. The runtime removed that version, so `spiced` refuses to start at all:

```
ERROR spiced: Failed to start Spice runtime: Unable to load spicepod .../test/scripts:
Unsupported Spicepod version in .../test/scripts: 'v1beta1'
Supported versions are: v1, v2 (or full semver: v1.0.0, v2.0.0-rc.1, etc.)
```

Because the runtime never comes up, the tests fail on transport errors rather than on anything they assert — `connect ECONNREFUSED 127.0.0.1:8090` for the HTTP calls and `14 UNAVAILABLE: No connection established` for Flight. The reported failures (`expect(isHealthy).toBe(true)`, `expect(isReady).toBe(true)`) are symptoms of a dead runtime, which is why the error is easy to misread as a product regression.

Confirmed repo-wide, not branch-specific: it fails identically on #311, on lukekim's #313, and on dependabot #306 — a pure dependency bump that touches no source at all.

## Fix

The Spicepod body is already `v1`-shaped, so the version string is the only change. `v1` also matches the convention used across the runtime repo's own test Spicepods.

## Not addressed here

Two other checks are red for reasons outside this repo's control, and this PR deliberately leaves them alone:

- **`Cloud Tests`** — `SPICEAI_API_KEY` and `SCP_SPICEAI_TPCH_API_KEY` arrive empty (`Secret source: None`), because GitHub withholds repo secrets from fork PRs.
- **`Vercel`** — `Authorization required to deploy`, same fork-secret restriction.

<!-- fix-failing-prs: dedicated ci-unbreak for spice.js v1beta1 -->