### PR TITLE
ci: use Spicepod v2 in the test fixture

### DIFF
--- a/test/scripts/spicepod.yaml
+++ b/test/scripts/spicepod.yaml
@@ -1,4 +1,4 @@
-version: v1
+version: v2
 kind: Spicepod
 name: test_spicejs
 datasets:

--- a/test/scripts/spicepod.yaml
+++ b/test/scripts/spicepod.yaml
@@ -1,4 +1,4 @@
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test_spicejs
 datasets:


### PR DESCRIPTION
## What

Changes `version: v1beta1` to `version: v2` in `test/scripts/spicepod.yaml`. One line.

## Why

Current `spiced` rejects `v1beta1` outright:

```
Failed to start Spice runtime: Unable to load spicepod .../test/scripts:
Unsupported Spicepod version in .../test/scripts: 'v1beta1'

Supported versions are: v1, v2 (or full semver: v1.0.0, v2.0.0-rc.1, etc.)
```

With no spicepod loaded the runtime never starts serving, so every `Local Runtime` test fails with `connect ECONNREFUSED 127.0.0.1:8090` — 15 failed / 3 passed per matrix entry.

This is repo-wide, not specific to any change: PRs #311, #312 and #313 all fail identically. It's version drift between the fixture and the installed runtime, which will keep every PR red until it's fixed.

## Verification

Ran `spiced` locally against the amended fixture (verified under both `v1` and `v2`; `v2` is what `spice init` emits, so the fixture now matches the CLI rather than trailing it). The `Unsupported Spicepod version` error is gone, both datasets are picked up, and the runtime serves:

```
runtime::init::dataset: Loading datasets: 2 tasks dispatched, 0 skipped (of 2 total)
runtime::init::dataset: Dataset test_postgresql_table_not_accelerated initializing...
runtime::init::dataset: Dataset test_postgresql_table_accelerated initializing...
runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
```

Both datasets then fail to connect to PostgreSQL, which is expected — there's no postgres on this machine. CI provides one via its `services:` block, so that part is exercised there.

Deliberately scoped to the one line; no other fixture or workflow changes.
