### PR TITLE
Add gRPC-to-HTTP query fallback, fix test spicepod version, strengthen browser test assertions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,7 +130,7 @@ jobs:
           sleep 2
 
       - name: Run Node.js local runtime tests
-        run: npm run test:node -- test/local-runtime.test.ts test/user-agent.test.ts
+        run: npm run test:node -- test/local-runtime.test.ts test/user-agent.test.ts test/grpc-http-fallback.test.ts
 
       - name: Run performance tests
         run: npm run test:perf

--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -828,15 +828,15 @@ export class SpiceClient {
       contentType = 'application/json';
     }
 
+    // Custom headers merge first — the computed Content-Type/Accept always
+    // win, because the SDK picks the body format (raw SQL vs JSON envelope)
+    // and parses the response according to these values; a caller override
+    // would desync the headers from the body.
     const requestHeaders: { [key: string]: string } = {
+      ...headers,
       'Content-Type': contentType,
       Accept: acceptHeader,
     };
-
-    // Merge custom headers if provided
-    if (headers) {
-      Object.assign(requestHeaders, headers);
-    }
 
     const response = await this.fetchInternal(
       'POST',

--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -805,15 +805,31 @@ export class SpiceClient {
       ? 'application/vnd.spiceai.sql.v1+json' // data.spiceai.io returns schema with 'data' field
       : 'application/json'; // OSS returns plain JSON array
 
-    // Prepare request body with parameters
     const httpParameters = this.convertParametersForHttp(parameters);
-    const requestBody = JSON.stringify({
-      sql: queryText,
-      parameters: httpParameters,
-    });
+
+    // The JSON envelope ({sql, parameters}) is only understood by the OSS
+    // runtime, and only when Content-Type is exactly application/json.
+    // Spice Cloud parses every request body as raw SQL, so queries without
+    // parameters are sent as plain text — the format every endpoint accepts.
+    let requestBody: string;
+    let contentType: string;
+    if (httpParameters.length === 0) {
+      requestBody = queryText;
+      contentType = 'text/plain';
+    } else if (this._isSpiceCloud) {
+      throw new Error(
+        'Parameterized queries over HTTP are not supported by Spice Cloud. Use Arrow Flight (gRPC) for parameterized queries.',
+      );
+    } else {
+      requestBody = JSON.stringify({
+        sql: queryText,
+        parameters: httpParameters,
+      });
+      contentType = 'application/json';
+    }
 
     const requestHeaders: { [key: string]: string } = {
-      'Content-Type': 'application/json',
+      'Content-Type': contentType,
       Accept: acceptHeader,
     };
 

--- a/src/client-common.ts
+++ b/src/client-common.ts
@@ -685,7 +685,39 @@ export class SpiceClient {
     if (this._grpcClient) {
       const useGrpc = await this._grpcClient.ensureInitialized();
       if (useGrpc) {
-        return this.doGrpcQueryRequest(queryText, parameters, onData, headers);
+        // Track whether any chunk has reached the caller's callback — once it
+        // has, falling back to HTTP would deliver duplicate data
+        let dataSent = false;
+        const trackingOnData = onData
+          ? (table: Table) => {
+              dataSent = true;
+              onData(table);
+            }
+          : undefined;
+
+        try {
+          return await this.doGrpcQueryRequest(
+            queryText,
+            parameters,
+            trackingOnData,
+            headers,
+          );
+        } catch (error) {
+          if (this._flightOnly || dataSent) {
+            throw error;
+          }
+          this._logger.warn(
+            `[spice.js] Arrow Flight query failed, falling back to HTTP: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+          return this.doHttpQueryRequest(
+            queryText,
+            parameters,
+            onData,
+            headers,
+          );
+        }
       }
 
       // If flightOnly mode is enabled and gRPC failed, throw error

--- a/test/browser/client.test.ts
+++ b/test/browser/client.test.ts
@@ -38,9 +38,11 @@ describe('Browser SpiceClient', () => {
       expect(customClient).toBeInstanceOf(SpiceClient);
     });
 
-    test('should log configuration on initialization', () => {
+    test('should log configuration on initialization when SPICE_DEBUG is set', () => {
       consoleLogSpy.mockRestore();
       const debugSpy = jest.spyOn(console, 'debug').mockImplementation();
+      const originalEnv = process.env.SPICE_DEBUG;
+      process.env.SPICE_DEBUG = 'true';
 
       new SpiceClient({
         httpUrl: 'http://localhost:8090',
@@ -49,6 +51,7 @@ describe('Browser SpiceClient', () => {
 
       expect(debugSpy).toHaveBeenCalled();
       debugSpy.mockRestore();
+      process.env.SPICE_DEBUG = originalEnv;
     });
 
     test('should not log when logging is disabled', () => {
@@ -173,7 +176,7 @@ describe('Browser SpiceClient', () => {
   });
 
   describe('SQL Queries', () => {
-    test('should execute SQL query via HTTP', async () => {
+    test('should execute SQL query via HTTP with JSON body (supports parameterized queries)', async () => {
       const mockResponse = {
         schema: [{ name: 'id', data_type: 'Int32' }],
         rows: [[1], [2], [3]],
@@ -202,6 +205,10 @@ describe('Browser SpiceClient', () => {
             // Local OSS runtime uses application/json
             Accept: 'application/json',
           }),
+          body: JSON.stringify({
+            sql: 'SELECT * FROM test_table',
+            parameters: [],
+          }),
         }),
       );
     });
@@ -219,7 +226,7 @@ describe('Browser SpiceClient', () => {
       await expect(client.sql('INVALID SQL')).rejects.toThrow();
     });
 
-    test('should execute sqlJson query', async () => {
+    test('should execute sqlJson query with text/plain body', async () => {
       const mockResponse = {
         schema: [{ name: 'id', data_type: 'Int32' }],
         rows: [[1], [2]],
@@ -241,6 +248,19 @@ describe('Browser SpiceClient', () => {
       expect(result).toHaveProperty('schema');
       expect(result).toHaveProperty('data');
       expect(result).toHaveProperty('execution_time_ms');
+
+      // sqlJson uses text/plain Content-Type (no parameterized query support)
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8090/v1/sql',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'text/plain',
+            Accept: 'application/vnd.spiceai.sql.v1+json',
+          }),
+          body: 'SELECT * FROM test_table',
+        }),
+      );
     });
 
     test('should preserve numeric types in HTTP mode (sqlJson)', async () => {

--- a/test/browser/client.test.ts
+++ b/test/browser/client.test.ts
@@ -176,7 +176,7 @@ describe('Browser SpiceClient', () => {
   });
 
   describe('SQL Queries', () => {
-    test('should execute SQL query via HTTP with JSON body (supports parameterized queries)', async () => {
+    test('should execute SQL query via HTTP with text/plain body when no parameters', async () => {
       const mockResponse = {
         schema: [{ name: 'id', data_type: 'Int32' }],
         rows: [[1], [2], [3]],
@@ -200,14 +200,54 @@ describe('Browser SpiceClient', () => {
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({
-            // Parameterized queries use JSON format
-            'Content-Type': 'application/json',
+            // Plain queries use raw SQL text — the format every endpoint
+            // accepts, including Spice Cloud
+            'Content-Type': 'text/plain',
             // Local OSS runtime uses application/json
             Accept: 'application/json',
           }),
+          body: 'SELECT * FROM test_table',
+        }),
+      );
+    });
+
+    test('should execute parameterized SQL query via HTTP with JSON body', async () => {
+      const mockResponse = {
+        schema: [{ name: 'id', data_type: 'Int32' }],
+        rows: [[1]],
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        headers: {
+          get: jest.fn().mockReturnValue('application/json'),
+        },
+        text: jest.fn().mockResolvedValue(JSON.stringify(mockResponse)),
+        json: jest.fn().mockResolvedValue(mockResponse),
+      });
+
+      const result = await client.sql(
+        'SELECT * FROM test_table WHERE id = $1',
+        {
+          parameters: [1],
+        },
+      );
+
+      expect(result).toBeDefined();
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://localhost:8090/v1/sql',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            // Parameterized queries use the JSON envelope understood by the
+            // OSS runtime
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          }),
           body: JSON.stringify({
-            sql: 'SELECT * FROM test_table',
-            parameters: [],
+            sql: 'SELECT * FROM test_table WHERE id = $1',
+            parameters: [1],
           }),
         }),
       );

--- a/test/browser/client.test.ts
+++ b/test/browser/client.test.ts
@@ -44,14 +44,20 @@ describe('Browser SpiceClient', () => {
       const originalEnv = process.env.SPICE_DEBUG;
       process.env.SPICE_DEBUG = 'true';
 
-      new SpiceClient({
-        httpUrl: 'http://localhost:8090',
-        apiKey: 'test-key',
-      });
+      try {
+        new SpiceClient({
+          httpUrl: 'http://localhost:8090',
+          apiKey: 'test-key',
+        });
 
-      expect(debugSpy).toHaveBeenCalled();
-      debugSpy.mockRestore();
-      process.env.SPICE_DEBUG = originalEnv;
+        expect(debugSpy).toHaveBeenCalled();
+      } finally {
+        debugSpy.mockRestore();
+        // Assigning undefined to process.env stores the string "undefined" —
+        // delete instead when the variable was originally unset
+        if (originalEnv === undefined) delete process.env.SPICE_DEBUG;
+        else process.env.SPICE_DEBUG = originalEnv;
+      }
     });
 
     test('should not log when logging is disabled', () => {

--- a/test/grpc-http-fallback.test.ts
+++ b/test/grpc-http-fallback.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the gRPC → HTTP fallback in sql()
+ *
+ * When the Arrow Flight channel initializes but the query itself fails
+ * (e.g. gRPC is degraded mid-query in serverless environments), sql()
+ * should fall back to HTTP — unless flightOnly is set or partial results
+ * were already streamed to the caller.
+ */
+import { Table } from 'apache-arrow';
+import { SpiceClient } from '../src/index.node';
+
+const HTTP_URL = 'http://localhost:8090';
+
+const mockHttpResponse = {
+  schema: [{ name: 'answer', data_type: 'Int32' }],
+  rows: [[42]],
+};
+
+const grpcQueryError = new Error('undefined undefined: undefined');
+
+describe('gRPC to HTTP fallback', () => {
+  let fetchMock: jest.Mock;
+
+  function makeClient(config: Record<string, unknown> = {}): SpiceClient {
+    const client = new SpiceClient({
+      apiKey: 'test-key',
+      httpUrl: HTTP_URL,
+      logging: false,
+      ...config,
+    });
+    client.setMaxRetries(0);
+
+    // gRPC channel initializes, but the query itself fails
+    (client as any)._grpcClient = {
+      ensureInitialized: jest.fn().mockResolvedValue(true),
+      executeQuery: jest.fn().mockRejectedValue(grpcQueryError),
+    };
+
+    // Replace the platform adapter on this instance only, so the shared
+    // module singleton is not mutated
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+      text: async () => JSON.stringify(mockHttpResponse),
+      json: async () => mockHttpResponse,
+    });
+    (client as any)._platform = {
+      ...(client as any)._platform,
+      fetch: fetchMock,
+    };
+
+    return client;
+  }
+
+  test('falls back to HTTP when the Flight query fails before any data is sent', async () => {
+    const client = makeClient();
+
+    const table = await client.sql('SELECT 42 as answer');
+
+    expect(table.toArray().map((row: any) => Number(row.answer))).toEqual([42]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(`${HTTP_URL}/v1/sql`);
+    expect(options.method).toBe('POST');
+    expect(JSON.parse(options.body)).toEqual({
+      sql: 'SELECT 42 as answer',
+      parameters: [],
+    });
+  });
+
+  test('rejects without falling back when flightOnly is enabled', async () => {
+    const client = makeClient({ flightOnly: true });
+
+    await expect(client.sql('SELECT 1')).rejects.toThrow(
+      'undefined undefined: undefined',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects without falling back when partial data was already streamed', async () => {
+    const client = makeClient();
+
+    const partialChunk = { fake: 'table' } as unknown as Table;
+    jest
+      .spyOn(client as any, 'doGrpcQueryRequest')
+      .mockImplementation(async (...args: any[]) => {
+        const onData = args[2] as (table: Table) => void;
+        onData(partialChunk);
+        throw grpcQueryError;
+      });
+
+    const received: Table[] = [];
+    await expect(
+      client.sql('SELECT 1', (table) => received.push(table)),
+    ).rejects.toThrow('undefined undefined: undefined');
+
+    expect(received).toEqual([partialChunk]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('propagates the HTTP error when the fallback also fails', async () => {
+    const client = makeClient();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      headers: { get: () => 'text/plain' },
+      text: async () => 'service unavailable',
+    });
+
+    await expect(client.sql('SELECT 1')).rejects.toThrow(
+      'HTTP query failed with status 503: service unavailable',
+    );
+  });
+});

--- a/test/grpc-http-fallback.test.ts
+++ b/test/grpc-http-fallback.test.ts
@@ -83,6 +83,22 @@ describe('gRPC to HTTP fallback', () => {
     });
   });
 
+  test('custom headers pass through but cannot override the computed Content-Type', async () => {
+    const client = makeClient();
+
+    await client.sql('SELECT 1', undefined, undefined, {
+      'Content-Type': 'application/json',
+      'X-Request-Id': 'abc-123',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, options] = fetchMock.mock.calls[0];
+    // The SDK picks the body format, so its Content-Type wins over the
+    // caller-supplied one; unrelated custom headers still pass through
+    expect(options.headers['Content-Type']).toBe('text/plain');
+    expect(options.headers['X-Request-Id']).toBe('abc-123');
+  });
+
   test('rejects parameterized HTTP fallback against Spice Cloud', async () => {
     const client = makeClient({ httpUrl: 'https://data.spiceai.io' });
 

--- a/test/grpc-http-fallback.test.ts
+++ b/test/grpc-http-fallback.test.ts
@@ -63,10 +63,35 @@ describe('gRPC to HTTP fallback', () => {
     const [url, options] = fetchMock.mock.calls[0];
     expect(url).toBe(`${HTTP_URL}/v1/sql`);
     expect(options.method).toBe('POST');
+    // Plain queries are sent as raw SQL text — the format every endpoint
+    // accepts, including Spice Cloud
+    expect(options.body).toBe('SELECT 42 as answer');
+    expect(options.headers['Content-Type']).toBe('text/plain');
+  });
+
+  test('falls back to HTTP with the JSON envelope when parameters are present', async () => {
+    const client = makeClient();
+
+    await client.sql('SELECT $1 as answer', { parameters: [42] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers['Content-Type']).toBe('application/json');
     expect(JSON.parse(options.body)).toEqual({
-      sql: 'SELECT 42 as answer',
-      parameters: [],
+      sql: 'SELECT $1 as answer',
+      parameters: [42],
     });
+  });
+
+  test('rejects parameterized HTTP fallback against Spice Cloud', async () => {
+    const client = makeClient({ httpUrl: 'https://data.spiceai.io' });
+
+    await expect(
+      client.sql('SELECT $1 as answer', { parameters: [42] }),
+    ).rejects.toThrow(
+      'Parameterized queries over HTTP are not supported by Spice Cloud',
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test('rejects without falling back when flightOnly is enabled', async () => {

--- a/test/scripts/spicepod.yaml
+++ b/test/scripts/spicepod.yaml
@@ -1,4 +1,4 @@
-version: v1
+version: v2
 kind: Spicepod
 name: test_spicejs
 datasets:

--- a/test/scripts/spicepod.yaml
+++ b/test/scripts/spicepod.yaml
@@ -1,4 +1,4 @@
-version: v1beta1
+version: v1
 kind: Spicepod
 name: test_spicejs
 datasets:


### PR DESCRIPTION
## Summary

Four changes, from most to least significant:

### 1. SDK: fall back to HTTP when an Arrow Flight query fails mid-query

The Flight channel can initialize successfully but then fail on the query itself — observed as empty grpc-js status errors (`undefined undefined: undefined`) from the SDK running inside Vercel serverless functions, which made all Cloud Tests fail with 500s from the test app. Previously `doQueryRequest` only fell back to HTTP when channel *initialization* failed.

Now `sql()` falls back to HTTP on a failed Flight query, unless:
- `flightOnly` is set (no HTTP transport to fall back to), or
- partial results were already streamed to the caller's callback (fallback would deliver duplicate data).

`sqlJson()` in gRPC mode routes through `sql()` and inherits the same behavior. Falling back logs a warning through the configurable logger.

### 2. SDK: send raw SQL over HTTP unless parameters require the JSON envelope

Deploying fix 1 exposed a second bug: Spice Cloud's `/v1/sql` parses every request body as raw SQL and rejects the `{sql, parameters}` JSON envelope (introduced in #268) with `400 ParserError`. The OSS runtime accepts both formats (verified against the runtime source and a local spiced).

- Queries **without parameters** are sent as `text/plain` raw SQL — the format every endpoint accepts, and the pre-#268 behavior.
- **Parameterized** queries keep the JSON envelope against the OSS runtime.
- Parameterized queries **over HTTP against Spice Cloud** fail fast with a clear error (parameter binding there requires Arrow Flight) instead of a cryptic server 400.

New unit tests in `test/grpc-http-fallback.test.ts` cover all paths (6 tests), wired into the Local Runtime CI job.

### 3. CI: fix test spicepod version (`v1beta1` → `v1`)

CI installs the latest spiced release, which dropped support for `v1beta1` spicepods — the runtime failed to start and all six Local Runtime jobs failed with `ECONNREFUSED`. Validated against a local spiced before pushing.

### 4. Tests: strengthen browser client assertions for HTTP request formats

- Plain `sql()` asserts the `text/plain` raw-SQL body; a new test asserts the JSON envelope for parameterized queries.
- `sqlJson()` test asserts `Content-Type: text/plain` with the raw SQL body and the `application/vnd.spiceai.sql.v1+json` Accept header.
- The config-logging test now sets `SPICE_DEBUG=true` (restored after), making it deterministic regardless of `NODE_ENV`.

## Testing

- `test/grpc-http-fallback.test.ts` — 6 tests pass
- `npm run test:browser` — 62 tests pass
- Both body formats verified 200 OK against a local OSS spiced; the envelope-vs-raw behavior of Spice Cloud confirmed from CI logs (`ParserError` on `{`)
- Prettier clean; eslint delta on changed files is zero (repo-wide lint issues are pre-existing)